### PR TITLE
Update Dockerfile to use multi-stage build

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,14 +1,23 @@
-FROM golang:1.7.5-alpine
+FROM golang:1.7.5-alpine AS builder
+
+WORKDIR /app/
 
 ADD ./vendor /go/src/
 ADD ./*.go /app/
 
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /app/main
+
+# MULTI-STAGE BUILD PATTERN
+
+FROM alpine:latest
+
+RUN set -x \
+      && mkdir -p /var/www/.well-known/ \
+      && mkdir -p /etc/auto-kubernetes-lets-encrypt/certs/ \
+      && echo "This is the index for .well-known" >> /var/www/.well-known/index.html
+
 WORKDIR /app/
-RUN go build -o /app/main
-RUN mkdir -p /var/www/.well-known/
-RUN mkdir -p /etc/auto-kubernetes-lets-encrypt/certs/
-RUN echo "This is the index for .well-known" >> /var/www/.well-known/index.html
+COPY --from=builder /app/main /app/main
 
 EXPOSE 80
-
 CMD ["/app/main"]


### PR DESCRIPTION
### Motivation
Docker has released a new feature that allows a new way of writing [Dockerfiles in multiple stages.](https://docs.docker.com/engine/userguide/eng-image/multistage-build/) This PR implements the new multi-stage builds feature. Below are the results:
```
auto-kube-le-new    latest              ebeeb1c90564        3 minutes ago       12.5MB
auto-kube-le-old    latest              5142ddcef2b6        4 minutes ago       259MB
```
**Note: This will only work for Docker v17.05.0-ce and above**